### PR TITLE
Fix: Refund issue

### DIFF
--- a/contracts/ERC721RExample.sol
+++ b/contracts/ERC721RExample.sol
@@ -87,7 +87,7 @@ contract ERC721RExample is ERC721A, Ownable {
         for (uint256 i = 0; i < tokenIds.length; i++) {
             uint256 tokenId = tokenIds[i];
             require(msg.sender == ownerOf(tokenId), "Not token owner");
-            transferFrom(msg.sender, refundAddress, tokenId);
+            transferFrom(msg.sender, address(0), tokenId);
         }
 
         uint256 refundAmount = tokenIds.length * mintPrice;


### PR DESCRIPTION
RefundAddress can transfer nfts to other address and get refund. It means team still can rug.
So I changed transferFrom(msg.sender, refundAddress, tokenId); to transferFrom(msg.sender, address(0), tokenId);