### PR TITLE
Fix: Owner Not allow to call the refund

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "singleQuote": false,
+  "bracketSameLine":false
+}

--- a/contracts/ERC721RExample.sol
+++ b/contracts/ERC721RExample.sol
@@ -28,6 +28,11 @@ contract ERC721RExample is ERC721A, Ownable {
         _;
     }
 
+    modifier notOwner(){
+        require(!(owner() == _msgSender()), "Owner not allow");
+        _;
+    }
+
     constructor() ERC721A("ERC721RExample", "ERC721R") {
         refundAddress = msg.sender;
         toggleRefundCountdown();
@@ -73,6 +78,8 @@ contract ERC721RExample is ERC721A, Ownable {
         _safeMint(msg.sender, quantity);
     }
 
+
+    // I will set a timeline for that, maybe a year
     function ownerMint(uint256 quantity) external onlyOwner {
         require(
             amountMinted + quantity <= maxMintSupply,
@@ -81,7 +88,7 @@ contract ERC721RExample is ERC721A, Ownable {
         _safeMint(msg.sender, quantity);
     }
 
-    function refund(uint256[] calldata tokenIds) external {
+    function refund(uint256[] calldata tokenIds) external notOwner {
         require(refundGuaranteeActive(), "Refund expired");
 
         for (uint256 i = 0; i < tokenIds.length; i++) {

--- a/contracts/ERC721RExample.sol
+++ b/contracts/ERC721RExample.sol
@@ -79,7 +79,6 @@ contract ERC721RExample is ERC721A, Ownable {
     }
 
 
-    // I will set a timeline for that, maybe a year
     function ownerMint(uint256 quantity) external onlyOwner {
         require(
             amountMinted + quantity <= maxMintSupply,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "erc721r",
+  "name": "ERC721R",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -12270,9 +12270,9 @@
       }
     },
     "node_modules/hardhat": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.9.2.tgz",
-      "integrity": "sha512-elTcUK1EdFverWinybQ+DoJzsM6sgiHUYs0ZYNNXMfESty6ESHiFSwkfJsC88/q09vmIz6YVaMh73BYnYd+feQ==",
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.9.3.tgz",
+      "integrity": "sha512-7Vw99RbYbMZ15UzegOR/nqIYIqddZXvLwJGaX5sX4G5bydILnbjmDU6g3jMKJSiArEixS3vHAEaOs5CW1JQ3hg==",
       "dev": true,
       "dependencies": {
         "@ethereumjs/block": "^3.6.0",
@@ -24616,9 +24616,9 @@
       }
     },
     "hardhat": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.9.2.tgz",
-      "integrity": "sha512-elTcUK1EdFverWinybQ+DoJzsM6sgiHUYs0ZYNNXMfESty6ESHiFSwkfJsC88/q09vmIz6YVaMh73BYnYd+feQ==",
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.9.3.tgz",
+      "integrity": "sha512-7Vw99RbYbMZ15UzegOR/nqIYIqddZXvLwJGaX5sX4G5bydILnbjmDU6g3jMKJSiArEixS3vHAEaOs5CW1JQ3hg==",
       "dev": true,
       "requires": {
         "@ethereumjs/block": "^3.6.0",

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,5 @@
-const { expect } = require("chai");
-const { ethers } = require("hardhat");
+const {expect} = require('chai');
+const {ethers} = require('hardhat');
 
 const parseEther = ethers.utils.parseEther;
 
@@ -7,12 +7,12 @@ let owner;
 let account2;
 let erc721RExample;
 
-const MINT_PRICE = "0.1";
+const MINT_PRICE = '0.1';
 
-describe("ERC721RExample", function () {
+describe('ERC721RExample', function () {
   before(async function () {
     [owner, account2, account3, account4] = await ethers.getSigners();
-    const ERC721RExample = await ethers.getContractFactory("ERC721RExample");
+    const ERC721RExample = await ethers.getContractFactory('ERC721RExample');
     erc721RExample = await ERC721RExample.deploy();
     await erc721RExample.deployed();
 
@@ -23,20 +23,23 @@ describe("ERC721RExample", function () {
     expect(publicSaleActive).to.be.equal(true);
   });
 
-  it("Should be able to deploy", async function () {});
+  it('Should be able to deploy', async function () {});
 
-  it("Should be able to mint and request a refund", async function () {
-    await erc721RExample
-      .connect(account2)
-      .publicSaleMint(1, { value: parseEther(MINT_PRICE) });
+  it('Should be able to mint and request a refund', async function () {
+    await erc721RExample.connect(account2).publicSaleMint(1, {value: parseEther(MINT_PRICE)});
     const balanceAfterMint = await erc721RExample.balanceOf(account2.address);
     expect(balanceAfterMint).to.be.equal(1);
     await erc721RExample.connect(account2).refund([0]);
     const balanceAfterRefund = await erc721RExample.balanceOf(account2.address);
     expect(balanceAfterRefund).to.be.equal(0);
-    const balanceAfterRefundOfOwner = await erc721RExample.balanceOf(
-      owner.address
-    );
+    const balanceAfterRefundOfOwner = await erc721RExample.balanceOf(owner.address);
     expect(balanceAfterRefundOfOwner).to.be.equal(1);
+  });
+
+  it('Owner is not allow to request a refund', async function () {
+    await erc721RExample.connect(owner).publicSaleMint(1, {value: parseEther(MINT_PRICE)});
+    const balanceAfterMint = await erc721RExample.balanceOf(owner.address);
+    expect(balanceAfterMint).to.be.equal(2);
+    await expect(erc721RExample.connect(owner).refund([0])).to.be.revertedWith('Owner not allow');
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,5 @@
-const {expect} = require('chai');
-const {ethers} = require('hardhat');
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
 
 const parseEther = ethers.utils.parseEther;
 
@@ -7,12 +7,12 @@ let owner;
 let account2;
 let erc721RExample;
 
-const MINT_PRICE = '0.1';
+const MINT_PRICE = "0.1";
 
-describe('ERC721RExample', function () {
+describe("ERC721RExample", function () {
   before(async function () {
     [owner, account2, account3, account4] = await ethers.getSigners();
-    const ERC721RExample = await ethers.getContractFactory('ERC721RExample');
+    const ERC721RExample = await ethers.getContractFactory("ERC721RExample");
     erc721RExample = await ERC721RExample.deploy();
     await erc721RExample.deployed();
 
@@ -23,23 +23,31 @@ describe('ERC721RExample', function () {
     expect(publicSaleActive).to.be.equal(true);
   });
 
-  it('Should be able to deploy', async function () {});
+  it("Should be able to deploy", async function () {});
 
-  it('Should be able to mint and request a refund', async function () {
-    await erc721RExample.connect(account2).publicSaleMint(1, {value: parseEther(MINT_PRICE)});
+  it("Should be able to mint and request a refund", async function () {
+    await erc721RExample
+      .connect(account2)
+      .publicSaleMint(1, { value: parseEther(MINT_PRICE) });
     const balanceAfterMint = await erc721RExample.balanceOf(account2.address);
     expect(balanceAfterMint).to.be.equal(1);
     await erc721RExample.connect(account2).refund([0]);
     const balanceAfterRefund = await erc721RExample.balanceOf(account2.address);
     expect(balanceAfterRefund).to.be.equal(0);
-    const balanceAfterRefundOfOwner = await erc721RExample.balanceOf(owner.address);
+    const balanceAfterRefundOfOwner = await erc721RExample.balanceOf(
+      owner.address
+    );
     expect(balanceAfterRefundOfOwner).to.be.equal(1);
   });
 
-  it('Owner is not allow to request a refund', async function () {
-    await erc721RExample.connect(owner).publicSaleMint(1, {value: parseEther(MINT_PRICE)});
+  it("Owner is not allow to request a refund", async function () {
+    await erc721RExample
+      .connect(owner)
+      .publicSaleMint(1, { value: parseEther(MINT_PRICE) });
     const balanceAfterMint = await erc721RExample.balanceOf(owner.address);
     expect(balanceAfterMint).to.be.equal(2);
-    await expect(erc721RExample.connect(owner).refund([0])).to.be.revertedWith('Owner not allow');
+    await expect(erc721RExample.connect(owner).refund([0])).to.be.revertedWith(
+      "Owner not allow"
+    );
   });
 });


### PR DESCRIPTION
Hi @elie222 

Here is the improvements.
1. Stop the owner of the contract from calling the refund function
   * Create a Modifier function called `notOwner` and being call over refund function.
   * Testing code was added as well over test file. 
 
2. To simplify contributions, I did include a prettier config file.
   * If other developers want to contribute, they need not to change their prettier setting over their vs code.
  
 Hopes it helps.
 
 Regards,
 Liang  
  
