### PR TITLE
test: move test to describe blocks to make it clear!

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -34,59 +34,30 @@ async function simulateNextBlockTime(baseTime, changeBy) {
   await mineSingleBlock();
 }
 
-describe("ERC721RExample", function () {
-  beforeEach(async function () {
-    [owner, account2, account3] = await ethers.getSigners();
+beforeEach(async function () {
+  [owner, account2, account3] = await ethers.getSigners();
 
-    merkleTree = getTree(
-      [owner.address, account2.address, account3.address].map((address) =>
-        solidityKeccak256(["address"], [address])
-      )
-    );
+  merkleTree = getTree(
+    [owner.address, account2.address, account3.address].map((address) =>
+      solidityKeccak256(["address"], [address])
+    )
+  );
 
-    const ERC721RExample = await ethers.getContractFactory("ERC721RExample");
-    erc721RExample = await ERC721RExample.deploy();
-    await erc721RExample.deployed();
-    blockDeployTimeStamp = (await erc721RExample.provider.getBlock("latest"))
-      .timestamp;
+  const ERC721RExample = await ethers.getContractFactory("ERC721RExample");
+  erc721RExample = await ERC721RExample.deploy();
+  await erc721RExample.deployed();
+  blockDeployTimeStamp = (await erc721RExample.provider.getBlock("latest"))
+    .timestamp;
 
-    const saleActive = await erc721RExample.publicSaleActive();
-    expect(saleActive).to.be.equal(false);
-    await erc721RExample.togglePublicSaleStatus();
-    const publicSaleActive = await erc721RExample.publicSaleActive();
-    expect(publicSaleActive).to.eq(true);
-  });
+  const saleActive = await erc721RExample.publicSaleActive();
+  expect(saleActive).to.be.equal(false);
+  await erc721RExample.togglePublicSaleStatus();
+  const publicSaleActive = await erc721RExample.publicSaleActive();
+  expect(publicSaleActive).to.eq(true);
+});
 
-  it(`[Check] Check maxMintSupply = ${MAX_MINT_SUPPLY}`, async function () {
-    expect(await erc721RExample.maxMintSupply()).to.be.equal(MAX_MINT_SUPPLY);
-  });
-
-  it(`[Check] Check mintPrice = ${MINT_PRICE}`, async function () {
-    expect(await erc721RExample.mintPrice()).to.be.equal(
-      parseEther(MINT_PRICE)
-    );
-  });
-
-  it(`[Check] Check refundPeriod ${REFUND_PERIOD}`, async function () {
-    expect(await erc721RExample.refundPeriod()).to.be.equal(REFUND_PERIOD);
-  });
-
-  it(`[Check] Check maxUserMintAmount ${MAX_USER_MINT_AMOUNT}`, async function () {
-    expect(await erc721RExample.maxUserMintAmount()).to.be.equal(
-      MAX_USER_MINT_AMOUNT
-    );
-  });
-
-  it("[Check] Check refundEndTime is same with block timestamp in first deploy", async function () {
-    const refundEndTime = await erc721RExample.getRefundGuaranteeEndTime();
-    expect(blockDeployTimeStamp + REFUND_PERIOD).to.be.equal(refundEndTime);
-  });
-
-  it(`[Check] Check refundGuaranteeActive = true`, async function () {
-    expect(await erc721RExample.isRefundGuaranteeActive()).to.be.true;
-  });
-
-  it("[Mint&Refund] Should be able to mint and request a refund", async function () {
+describe("Aggregation", function () {
+  it("Should be able to mint and request a refund", async function () {
     await erc721RExample
       .connect(account2)
       .publicSaleMint(1, { value: parseEther(MINT_PRICE) });
@@ -107,14 +78,99 @@ describe("ERC721RExample", function () {
     );
     expect(balanceAfterRefundOfOwner).to.eq(1);
   });
+});
 
-  it("[OwnerMint] Should able to mint", async function () {
+describe("Check ERC721RExample Constant & Variables", function () {
+  it(`Should maxMintSupply = ${MAX_MINT_SUPPLY}`, async function () {
+    expect(await erc721RExample.maxMintSupply()).to.be.equal(MAX_MINT_SUPPLY);
+  });
+
+  it(`Should mintPrice = ${MINT_PRICE}`, async function () {
+    expect(await erc721RExample.mintPrice()).to.be.equal(
+      parseEther(MINT_PRICE)
+    );
+  });
+
+  it(`Should refundPeriod ${REFUND_PERIOD}`, async function () {
+    expect(await erc721RExample.refundPeriod()).to.be.equal(REFUND_PERIOD);
+  });
+
+  it(`Should maxUserMintAmount ${MAX_USER_MINT_AMOUNT}`, async function () {
+    expect(await erc721RExample.maxUserMintAmount()).to.be.equal(
+      MAX_USER_MINT_AMOUNT
+    );
+  });
+
+  it("Should refundEndTime is same with block timestamp in first deploy", async function () {
+    const refundEndTime = await erc721RExample.getRefundGuaranteeEndTime();
+    expect(blockDeployTimeStamp + REFUND_PERIOD).to.be.equal(refundEndTime);
+  });
+
+  it(`Should refundGuaranteeActive = true`, async function () {
+    expect(await erc721RExample.isRefundGuaranteeActive()).to.be.true;
+  });
+});
+
+describe("Owner", function () {
+  it("Should be able to mint", async function () {
     await erc721RExample.ownerMint(1);
     expect(await erc721RExample.balanceOf(owner.address)).to.be.equal(1);
     expect(await erc721RExample.ownerOf(0)).to.be.equal(owner.address);
   });
 
-  it("[PublicMint:Revert] Should not be able to mint when `Public sale is not active`", async function () {
+  it("Should not be able to mint when `Max mint supply reached`", async function () {
+    await erc721RExample.provider.send("hardhat_setStorageAt", [
+      erc721RExample.address,
+      "0x9",
+      ethers.utils.solidityPack(["uint256"], [MAX_MINT_SUPPLY]), // 8000
+    ]);
+    await expect(erc721RExample.ownerMint(1)).to.be.revertedWith(
+      "Max mint supply reached"
+    );
+  });
+
+  it("Should not be withdraw when `Refund period not over`", async function () {
+    await expect(erc721RExample.connect(owner).withdraw()).to.revertedWith(
+      "Refund period not over"
+    );
+  });
+
+  it("Should be withdraw after refundEndTime", async function () {
+    const refundEndTime = await erc721RExample.getRefundGuaranteeEndTime();
+
+    await erc721RExample
+      .connect(account2)
+      .publicSaleMint(1, { value: parseEther(MINT_PRICE) });
+
+    await simulateNextBlockTime(refundEndTime, +11);
+
+    await erc721RExample.provider.send("hardhat_setBalance", [
+      owner.address,
+      "0x8e1bc9bf040000", // 0.04 ether
+    ]);
+    const ownerOriginBalance = await erc721RExample.provider.getBalance(
+      owner.address
+    );
+    // first check the owner balance is less than 0.1 ether
+    expect(ownerOriginBalance).to.be.lt(parseEther("0.1"));
+
+    await erc721RExample.connect(owner).withdraw();
+
+    const contractVault = await erc721RExample.provider.getBalance(
+      erc721RExample.address
+    );
+    const ownerBalance = await erc721RExample.provider.getBalance(
+      owner.address
+    );
+
+    expect(contractVault).to.be.equal(parseEther("0"));
+    // the owner origin balance is less than 0.1 ether
+    expect(ownerBalance).to.be.gt(parseEther("0.1"));
+  });
+});
+
+describe("PublicMint", function () {
+  it("Should not be able to mint when `Public sale is not active`", async function () {
     await erc721RExample.togglePublicSaleStatus();
     await expect(
       erc721RExample
@@ -123,13 +179,13 @@ describe("ERC721RExample", function () {
     ).to.be.revertedWith("Public sale is not active");
   });
 
-  it("[PublicMint:Revert] Should not be able to mint when `Not enough eth sent`", async function () {
+  it("Should not be able to mint when `Not enough eth sent`", async function () {
     await expect(
       erc721RExample.connect(account2).publicSaleMint(1, { value: 0 })
     ).to.be.revertedWith("Not enough eth sent");
   });
 
-  it("[PublicMint:Revert] Should not be able to mint when `Max mint supply reached`", async function () {
+  it("Should not be able to mint when `Max mint supply reached`", async function () {
     await erc721RExample.provider.send("hardhat_setStorageAt", [
       erc721RExample.address,
       "0x9",
@@ -142,7 +198,7 @@ describe("ERC721RExample", function () {
     ).to.be.revertedWith("Max mint supply reached");
   });
 
-  it("[PublicMint:Revert] Should not be able to mint when `Over mint limit`", async function () {
+  it("Should not be able to mint when `Over mint limit`", async function () {
     await erc721RExample
       .connect(account2)
       .publicSaleMint(5, { value: parseEther("0.5") });
@@ -152,8 +208,24 @@ describe("ERC721RExample", function () {
         .publicSaleMint(1, { value: parseEther(MINT_PRICE) })
     ).to.be.revertedWith("Over mint limit");
   });
+});
 
-  it("[PreSaleMint:Revert] Should not presale mint when `Not on allow list`", async function () {
+describe("PreSaleMint", function () {
+  it("Should presale mint merkle tree with valid leaf", async function () {
+    const proof = getProof(
+      merkleTree.tree,
+      solidityKeccak256(["address"], [account3.address])
+    );
+
+    await erc721RExample.setMerkleRoot(merkleTree.root);
+    await erc721RExample.togglePresaleStatus();
+    await erc721RExample.connect(account3).preSaleMint(1, proof, {
+      value: parseEther(MINT_PRICE),
+    });
+    expect(await erc721RExample.balanceOf(account3.address)).to.be.equal(1);
+  });
+
+  it("Should not presale mint when `Not on allow list`", async function () {
     await erc721RExample.provider.send("hardhat_setBalance", [
       owner.address,
       "0xffffffffffffffffffff",
@@ -175,21 +247,7 @@ describe("ERC721RExample", function () {
     expect(await erc721RExample.balanceOf(account2.address)).to.be.equal(0);
   });
 
-  it("[PreSaleMint] Should presale mint merkle tree with valid leaf", async function () {
-    const proof = getProof(
-      merkleTree.tree,
-      solidityKeccak256(["address"], [account3.address])
-    );
-
-    await erc721RExample.setMerkleRoot(merkleTree.root);
-    await erc721RExample.togglePresaleStatus();
-    await erc721RExample.connect(account3).preSaleMint(1, proof, {
-      value: parseEther(MINT_PRICE),
-    });
-    expect(await erc721RExample.balanceOf(account3.address)).to.be.equal(1);
-  });
-
-  it("[PreSaleMint:Revert] Should not be mint when `Presale is not active`", async function () {
+  it("Should not be mint when `Presale is not active`", async function () {
     const proof = getProof(
       merkleTree.tree,
       solidityKeccak256(["address"], [account2.address])
@@ -201,7 +259,7 @@ describe("ERC721RExample", function () {
     ).to.be.revertedWith("Presale is not active");
   });
 
-  it("[PreSaleMint:Revert] Should not be mint when `Value` not enough", async function () {
+  it("Should not be mint when `Value` not enough", async function () {
     await erc721RExample.togglePresaleStatus();
     await erc721RExample.setMerkleRoot(merkleTree.root);
 
@@ -215,7 +273,7 @@ describe("ERC721RExample", function () {
     ).to.be.revertedWith("Value");
   });
 
-  it("[PreSaleMint:Revert] Should not be mint when `Max amount`", async function () {
+  it("Should not be mint when `Max amount`", async function () {
     await erc721RExample.togglePresaleStatus();
     await erc721RExample.setMerkleRoot(merkleTree.root);
 
@@ -233,7 +291,7 @@ describe("ERC721RExample", function () {
     ).to.be.revertedWith("Max amount");
   });
 
-  it("[PreSaleMint:Revert] Should not be mint when `Max mint supply`", async function () {
+  it("Should not be mint when `Max mint supply`", async function () {
     await erc721RExample.togglePresaleStatus();
     await erc721RExample.setMerkleRoot(merkleTree.root);
     const proof = getProof(
@@ -251,8 +309,10 @@ describe("ERC721RExample", function () {
         .preSaleMint(1, proof, { value: parseEther(MINT_PRICE) })
     ).to.be.revertedWith("Max mint supply");
   });
+});
 
-  it("[Refund] Check hasRefunded store correct tokenId", async function () {
+describe("Refund", function () {
+  it("Should be store correct tokenId in refund", async function () {
     await erc721RExample
       .connect(account2)
       .publicSaleMint(5, { value: parseEther("0.5") });
@@ -260,15 +320,7 @@ describe("ERC721RExample", function () {
     expect(await erc721RExample.hasRefunded(3)).to.be.true;
   });
 
-  it("[Refund:Revert] Should not be refunded when `Not token owner`", async function () {
-    await erc721RExample.ownerMint(1);
-    expect(await erc721RExample.isOwnerMint(0)).to.be.equal(true);
-    await expect(
-      erc721RExample.connect(account2).refund([0])
-    ).to.be.revertedWith("Not token owner");
-  });
-
-  it("[Refund:Revert] `Freely minted NFTs cannot be refunded`", async function () {
+  it("Should be revert `Freely minted NFTs cannot be refunded`", async function () {
     await erc721RExample.ownerMint(1);
     expect(await erc721RExample.isOwnerMint(0)).to.be.equal(true);
     await expect(erc721RExample.refund([0])).to.be.revertedWith(
@@ -276,7 +328,29 @@ describe("ERC721RExample", function () {
     );
   });
 
-  it("[Refund:Revert] NFT cannot be refunded twice `Already refunded`", async function () {
+  it("Should be refund NFT in 45 days", async function () {
+    const refundEndTime = await erc721RExample.getRefundGuaranteeEndTime();
+
+    await erc721RExample
+      .connect(account2)
+      .publicSaleMint(1, { value: parseEther(MINT_PRICE) });
+
+    await erc721RExample.provider.send("evm_setNextBlockTimestamp", [
+      refundEndTime.toNumber(),
+    ]);
+
+    await erc721RExample.connect(account2).refund([0]);
+  });
+
+  it("Should not be refunded when `Not token owner`", async function () {
+    await erc721RExample.ownerMint(1);
+    expect(await erc721RExample.isOwnerMint(0)).to.be.equal(true);
+    await expect(
+      erc721RExample.connect(account2).refund([0])
+    ).to.be.revertedWith("Not token owner");
+  });
+
+  it("Should not be refunded NFT twice `Already refunded`", async function () {
     // update refund address and mint NFT from refund address
     await erc721RExample.setRefundAddress(account3.address);
     await erc721RExample
@@ -297,21 +371,7 @@ describe("ERC721RExample", function () {
     ).to.be.revertedWith("Already refunded");
   });
 
-  it("[Refund] NFT refund should in 45 days", async function () {
-    const refundEndTime = await erc721RExample.getRefundGuaranteeEndTime();
-
-    await erc721RExample
-      .connect(account2)
-      .publicSaleMint(1, { value: parseEther(MINT_PRICE) });
-
-    await erc721RExample.provider.send("evm_setNextBlockTimestamp", [
-      refundEndTime.toNumber(),
-    ]);
-
-    await erc721RExample.connect(account2).refund([0]);
-  });
-
-  it("[Refund:Revert] NFT refund expired after 45 days `Refund expired`", async function () {
+  it("Should not be refund NFT expired after 45 days `Refund expired`", async function () {
     const refundEndTime = await erc721RExample.getRefundGuaranteeEndTime();
 
     await erc721RExample
@@ -324,58 +384,10 @@ describe("ERC721RExample", function () {
       "Refund expired"
     );
   });
+});
 
-  it("[Owner:Revert] Owner should not be able to mint when `Max mint supply reached`", async function () {
-    await erc721RExample.provider.send("hardhat_setStorageAt", [
-      erc721RExample.address,
-      "0x9",
-      ethers.utils.solidityPack(["uint256"], [MAX_MINT_SUPPLY]), // 8000
-    ]);
-    await expect(erc721RExample.ownerMint(1)).to.be.revertedWith(
-      "Max mint supply reached"
-    );
-  });
-
-  it("[Owner:Revert] Owner can not withdraw when `Refund period not over`", async function () {
-    await expect(erc721RExample.connect(owner).withdraw()).to.revertedWith(
-      "Refund period not over"
-    );
-  });
-
-  it("[Owner] Owner can withdraw after refundEndTime", async function () {
-    const refundEndTime = await erc721RExample.getRefundGuaranteeEndTime();
-
-    await erc721RExample
-      .connect(account2)
-      .publicSaleMint(1, { value: parseEther(MINT_PRICE) });
-
-    await simulateNextBlockTime(refundEndTime, +11);
-
-    await erc721RExample.provider.send("hardhat_setBalance", [
-      owner.address,
-      "0x6a94d74f430000", // 0.03 ether
-    ]);
-    const ownerOriginBalance = await erc721RExample.provider.getBalance(
-      owner.address
-    );
-    // first check the owner balance is less than 0.1 ether
-    expect(ownerOriginBalance).to.be.lt(parseEther("0.1"));
-
-    await erc721RExample.connect(owner).withdraw();
-
-    const contractVault = await erc721RExample.provider.getBalance(
-      erc721RExample.address
-    );
-    const ownerBalance = await erc721RExample.provider.getBalance(
-      owner.address
-    );
-
-    expect(contractVault).to.be.equal(parseEther("0"));
-    // the owner origin balance is less than 0.1 ether
-    expect(ownerBalance).to.be.gt(parseEther("0.1"));
-  });
-
-  it("[Toggle] Owner can call toggleRefundCountdown and refundEndTime add `refundPeriod` days.", async function () {
+describe("Toogle", function () {
+  it("Should be call toggleRefundCountdown and refundEndTime add `refundPeriod` days.", async function () {
     const beforeRefundEndTime = (
       await erc721RExample.getRefundGuaranteeEndTime()
     ).toNumber();
@@ -393,22 +405,24 @@ describe("ERC721RExample", function () {
     expect(afterRefundEndTime).to.be.equal(beforeRefundEndTime + REFUND_PERIOD);
   });
 
-  it("[Toggle] Owner can call togglePresaleStatus", async function () {
+  it("Should be call togglePresaleStatus", async function () {
     await erc721RExample.togglePresaleStatus();
     expect(await erc721RExample.presaleActive()).to.be.true;
   });
 
-  it("[Toggle] Owner can call togglePublicSaleStatus", async function () {
+  it("Should be call togglePublicSaleStatus", async function () {
     await erc721RExample.togglePublicSaleStatus();
     expect(await erc721RExample.publicSaleActive()).to.be.false;
   });
+});
 
-  it("[Setter] Owner can call setRefundAddress", async function () {
+describe("Setter", function () {
+  it("Should be call setRefundAddress", async function () {
     await erc721RExample.setRefundAddress(account2.address);
     expect(await erc721RExample.refundAddress()).to.be.equal(account2.address);
   });
 
-  it("[Setter] Owner can call setMerkleRoot", async function () {
+  it("Should be call setMerkleRoot", async function () {
     await erc721RExample.setMerkleRoot(merkleTree.root);
     expect(await erc721RExample.merkleRoot()).to.be.equal(merkleTree.root);
   });


### PR DESCRIPTION
* move test to describe blocks

```
> erc721r@0.0.2 test
> npx hardhat test

  Aggregation
    ✔ Should be able to mint and request a refund (123ms)

  Check ERC721RExample Constant & Variables
    ✔ Should maxMintSupply = 8000
    ✔ Should mintPrice = 0.1
    ✔ Should refundPeriod 3888000
    ✔ Should maxUserMintAmount 5
    ✔ Should refundEndTime is same with block timestamp in first deploy
    ✔ Should refundGuaranteeActive = true

  Owner
    ✔ Should be able to mint
    ✔ Should not be able to mint when `Max mint supply reached` (47ms)
    ✔ Should not be withdraw when `Refund period not over`
    ✔ Should be withdraw after refundEndTime (44ms)

  PublicMint
    ✔ Should not be able to mint when `Public sale is not active`
    ✔ Should not be able to mint when `Not enough eth sent`
    ✔ Should not be able to mint when `Max mint supply reached`
    ✔ Should not be able to mint when `Over mint limit`

  PreSaleMint
    ✔ Should presale mint merkle tree with valid leaf (39ms)
    ✔ Should not presale mint when `Not on allow list`
    ✔ Should not be mint when `Presale is not active`
    ✔ Should not be mint when `Value` not enough
    ✔ Should not be mint when `Max amount` (48ms)
    ✔ Should not be mint when `Max mint supply`

  Refund
    ✔ Should be store correct tokenId in refund (51ms)
    ✔ Should be revert `Freely minted NFTs cannot be refunded`
    ✔ Should be refund NFT in 45 days (45ms)
    ✔ Should not be refunded when `Not token owner`
    ✔ Should not be refunded NFT twice `Already refunded` (80ms)
    ✔ Should not be refund NFT expired after 45 days `Refund expired`

  Toogle
    ✔ Should be call toggleRefundCountdown and refundEndTime add `refundPeriod` days.
    ✔ Should be call togglePresaleStatus
    ✔ Should be call togglePublicSaleStatus

  Setter
    ✔ Should be call setRefundAddress
    ✔ Should be call setMerkleRoot

  32 passing (4s)
```