### PR TITLE
Remove notContract check

### DIFF
--- a/contracts/ERC721RExample.sol
+++ b/contracts/ERC721RExample.sol
@@ -26,11 +26,6 @@ contract ERC721RExample is ERC721A, Ownable {
 
     string private baseURI;
 
-    modifier notContract() {
-        require(!Address.isContract(msg.sender), "No contracts");
-        _;
-    }
-
     constructor() ERC721A("ERC721RExample", "ERC721R") {
         refundAddress = msg.sender;
         toggleRefundCountdown();
@@ -39,7 +34,6 @@ contract ERC721RExample is ERC721A, Ownable {
     function preSaleMint(uint256 quantity, bytes32[] calldata proof)
         external
         payable
-        notContract
     {
         require(presaleActive, "Presale is not active");
         require(msg.value == quantity * mintPrice, "Value");
@@ -59,7 +53,7 @@ contract ERC721RExample is ERC721A, Ownable {
         _safeMint(msg.sender, quantity);
     }
 
-    function publicSaleMint(uint256 quantity) external payable notContract {
+    function publicSaleMint(uint256 quantity) external payable {
         require(publicSaleActive, "Public sale is not active");
         require(msg.value >= quantity * mintPrice, "Not enough eth sent");
         require(

--- a/contracts/cryptofighters/CryptoFightersV2.sol
+++ b/contracts/cryptofighters/CryptoFightersV2.sol
@@ -30,11 +30,6 @@ contract CryptoFightersV2 is ERC721A, Ownable, ReentrancyGuard {
     IERC721 private immutable cryptoFightersV1;
     CryptoFightersPotion private immutable cryptoFightersPotion;
 
-    modifier notContract() {
-        require(!Address.isContract(msg.sender), "No contracts");
-        _;
-    }
-
     constructor(address _cryptoFightersV1, address _cryptoFightersPotion)
         ERC721A("CryptoFightersAlliance", "CFA")
     {
@@ -68,7 +63,6 @@ contract CryptoFightersV2 is ERC721A, Ownable, ReentrancyGuard {
         external
         payable
         nonReentrant
-        notContract
     {
         require(presaleActive, "Presale is not active");
         require(msg.value == quantity * mintPrice, "Value");
@@ -92,7 +86,6 @@ contract CryptoFightersV2 is ERC721A, Ownable, ReentrancyGuard {
         external
         payable
         nonReentrant
-        notContract
     {
         require(publicSaleActive, "Public sale is not active");
         require(msg.value == quantity * mintPrice, "Value");


### PR DESCRIPTION
Bots still have a way around even with this in the contract and it breaks multisig wallets and more. Fixes https://github.com/exo-digital-labs/ERC721R/issues/22 and other open issues.