### PR TITLE
Clean Code - ERC721RExample.sol

### DIFF
--- a/contracts/ERC721RExample.sol
+++ b/contracts/ERC721RExample.sol
@@ -13,12 +13,10 @@ contract ERC721RExample is ERC721A, Ownable {
     // Sale Status
     bool public publicSaleActive;
     bool public presaleActive;
-    uint256 public amountMinted;
     uint256 public refundEndTime;
 
     address public refundAddress;
-    uint256 public maxUserMintAmount = 5;
-    mapping(address => uint256) public userMintedAmount;
+    uint256 public constant maxUserMintAmount = 5;
     bytes32 public merkleRoot;
 
     mapping(uint256 => bool) public hasRefunded; // users can search if the NFT has been refunded
@@ -42,13 +40,10 @@ contract ERC721RExample is ERC721A, Ownable {
             "Not on allow list"
         );
         require(
-            userMintedAmount[msg.sender] + quantity <= maxUserMintAmount,
+            _numberMinted(msg.sender) + quantity <= maxUserMintAmount,
             "Max amount"
         );
-        require(amountMinted + quantity <= maxMintSupply, "Max mint supply");
-
-        amountMinted += quantity;
-        userMintedAmount[msg.sender] += quantity;
+        require(_totalMinted() + quantity <= maxMintSupply, "Max mint supply");
 
         _safeMint(msg.sender, quantity);
     }
@@ -57,22 +52,20 @@ contract ERC721RExample is ERC721A, Ownable {
         require(publicSaleActive, "Public sale is not active");
         require(msg.value >= quantity * mintPrice, "Not enough eth sent");
         require(
-            userMintedAmount[msg.sender] + quantity <= maxUserMintAmount,
+            _numberMinted(msg.sender) + quantity <= maxUserMintAmount,
             "Over mint limit"
         );
         require(
-            amountMinted + quantity <= maxMintSupply,
+            _totalMinted() + quantity <= maxMintSupply,
             "Max mint supply reached"
         );
 
-        amountMinted += quantity;
-        userMintedAmount[msg.sender] += quantity;
         _safeMint(msg.sender, quantity);
     }
 
     function ownerMint(uint256 quantity) external onlyOwner {
         require(
-            amountMinted + quantity <= maxMintSupply,
+            _totalMinted() + quantity <= maxMintSupply,
             "Max mint supply reached"
         );
         _safeMint(msg.sender, quantity);

--- a/package.json
+++ b/package.json
@@ -22,7 +22,10 @@
     "type": "git",
     "url": "git+https://github.com/exo-digital-labs/ERC721R.git"
   },
-  "keywords": [],
+  "keywords": [
+    "solidity",
+    "erc721r"
+  ],
   "author": "exo-digital-labs",
   "license": "MIT",
   "bugs": {

--- a/test/test.js
+++ b/test/test.js
@@ -121,7 +121,7 @@ describe("Owner", function () {
   it("Should not be able to mint when `Max mint supply reached`", async function () {
     await erc721RExample.provider.send("hardhat_setStorageAt", [
       erc721RExample.address,
-      "0x9",
+      "0x0",
       ethers.utils.solidityPack(["uint256"], [MAX_MINT_SUPPLY]), // 8000
     ]);
     await expect(erc721RExample.ownerMint(1)).to.be.revertedWith(
@@ -188,7 +188,7 @@ describe("PublicMint", function () {
   it("Should not be able to mint when `Max mint supply reached`", async function () {
     await erc721RExample.provider.send("hardhat_setStorageAt", [
       erc721RExample.address,
-      "0x9",
+      "0x0",
       ethers.utils.solidityPack(["uint256"], [MAX_MINT_SUPPLY]), // 8000
     ]);
     await expect(
@@ -300,7 +300,7 @@ describe("PreSaleMint", function () {
     );
     await erc721RExample.provider.send("hardhat_setStorageAt", [
       erc721RExample.address,
-      "0x9",
+      "0x0",
       ethers.utils.solidityPack(["uint256"], [MAX_MINT_SUPPLY]), // 8000
     ]);
     await expect(


### PR DESCRIPTION

### ERC721RExample

By default, ERC721A already have
_numberMinted(msg.sender)
_totalMinted()

Replace
userMintedAmount[msg.sender]  -> _numberMinted(msg.sender)
amountMinted                              -> _totalMinted()

Code was getting cleaner and save cost for both deployment and minting.  😄 

---

### Test File
Test file was updated as well, slot 9 (amountMinted) was change to slot 0 (_currentIndex).

---

### Test Result (32 Test Passing)

![image](https://user-images.githubusercontent.com/34936929/163838687-1dbf870f-3c0d-4537-9bc4-e71b2a411fd2.png)


